### PR TITLE
Fix: IP Address Validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2543,7 +2543,7 @@ checksum = "94143f37725109f92c262ed2cf5e59bce7498c01bcc1502d7b9afe439a4e9f49"
 
 [[package]]
 name = "scs"
-version = "0.1.1"
+version = "0.1.2"
 dependencies = [
  "anyhow",
  "assert_fs",

--- a/config.yml
+++ b/config.yml
@@ -16,6 +16,6 @@ message: #Optional during receive
 file: #Optional during receive
 - "./dev_build.sh"
 debug: 1 #Compulsory. 0 is for off and 1 and above for on
-blacklists:
-- 127.0.0.1
-- 34.138.139.178
+# blacklists:
+# - 127.0.0.1
+# - 34.138.139.178

--- a/npm/package.json
+++ b/npm/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@onboardbase/secure-share",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "description": "Share anything with teammates across machines via CLI",
   "scripts": {
     "test": "jest",

--- a/npm/package.json
+++ b/npm/package.json
@@ -7,7 +7,7 @@
     "postinstall": "node ./install.js"
   },
   "bin": {
-    "share": "run.js"
+    "scs": "run.js"
   },
   "repository": {
     "type": "git",

--- a/share/Cargo.toml
+++ b/share/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "scs"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 default-run = "scs"
 description = "Open source p2p share for devs to share anything with teammates across machines securely."

--- a/share/src/main.rs
+++ b/share/src/main.rs
@@ -14,7 +14,7 @@ mod network;
 #[derive(Parser, Debug)]
 #[command(name = "scs")]
 #[command(author = "Onboardbase. <onboardbase.com>")]
-#[command(version = "0.1.1")]
+#[command(version = "0.1.2")]
 #[command(about = "Share anything with teammates across machines via CLI.", long_about = None)]
 pub struct Cli {
     /// Separated list of secrets to share. Key-Value pair is seperated by a comma. "my_key,my_value"


### PR DESCRIPTION
This PR aims to fix two bugs.
- The current bug with IP address validation that prevents `scs` from sharing/receiving items. 
The image below shows the error. 
This issue happens because sometimes, an `Incoming Message Event`  is not emitted before a connection is established. And since the `connection_id` is being set when this event occurs, during validation, the `id` can't be found because that event was not emitted.
Registering a `connection_id` has been moved to after the connection has been established.

![image](https://github.com/Onboardbase/secure-share/assets/52760545/3079abba-361d-46a8-a48a-86c16767374b)

- Secondly, the `npm` bin package was not changed to reflect the new name `scs`