### PR TITLE
Peer ID personalization

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Share anything with teammates across machines via CLI. Share is a tool for secur
   - [Files](#files)
   - [Messages](#messages)
   - [Configuration](#configuration)
-    - [Whitelists](#whitelists)
-    - [Signed Certs](#SignedCertificate)
+    - [Whitelists](#whitelistsblacklists-ip-addresses)
+    - [Signed Certs](#signed-certificate)
+    - [Seed Key](#seeds-seed-key)
 - [Update](#update)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -125,28 +126,24 @@ The sender then attempts to send the secret, and if it is successful, `scs` rela
 
 ```yaml
 port: 5555 #An optional port defaults to 0 if not present
-# The folder path to store all items.
-# Secrets will be stored at <path>/secrets.json
-# Messages at <path>/messages.txt
-# Files at <path>/nameoffile
-## If "default" is passed, the folder path will be `scs`'s directory in the machine's local folder.
 save_path: "default"
-secret: #Optional during receive
+secret: # Optional during receive
   - key: foo
     value: bar
   - key: baz
     value: woo
-message: #Optional during receive
+message: # Optional during receive
   - new message from me
   - test message
-file: #Optional during receive
+file: # Optional during receive
   - "./dev_build.sh"
-debug: 1 #Compulsory. 0 is for off, and 1 and above for on
+debug: 1 # Compulsory. 0 is for off, and 1 and above for on
 blacklists:
   - 34.138.139.178
 whitelists:
   - 34.193.14.12
-connection: trusted #or self
+connection: trusted # or self
+seed: "scsiscool"
 ```
 
   ```shell
@@ -163,6 +160,10 @@ connection: trusted #or self
 ### Signed Certificate
  Receivers can configure `scs` to only allow connections from users using a signed certificate from the CA. or just self-signed certificates. 
  Add a `connection: trusted` or `connection: self` to the configuration file.
+
+ ### Seeds (Seed Key)
+ The backbone of `scs` is `PeerId`. A `PeerId` a randomly generated key whenever a session is started for both the receiver and the sender. As of `v0.1.3` of `scs`, `PeerId`s can now be deterministic, that is, a single `PeerId` can be used for life. To do this, you need to set what is called a "seed". The `PeerId` is generated with respect to this seed. As long as the seed key remains the same, the `PeerId` will remain the same. 
+ The "seed" key is a string of any length lesser than 32. But for ease and optimal configuration, we recommend 4 or 5 letter words as in the above configuration file.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Contributions of any kind are welcome! See the [contributing guide](contributing
 # Roadmap
 
 ### Utilities
-- [ ] Personalize peer ID + allow saving recipient info (address, port, etc.) and giving a proper name so one can do "scs send dante -m Hello"
+- [x] Personalize peer ID.
+- [ ] Allow saving recipient info (address, port, etc.) and giving a proper name so one can do "scs send dante -m Hello"
 - [ ] Allow to always listen to specific addresses for an accessible data flow.
 
 ### Protocols

--- a/config.yml
+++ b/config.yml
@@ -19,3 +19,4 @@ debug: 1 #Compulsory. 0 is for off and 1 and above for on
 # blacklists:
 # - 127.0.0.1
 # - 34.138.139.178
+seed: "sour"

--- a/share/src/config.rs
+++ b/share/src/config.rs
@@ -208,6 +208,7 @@ mod tests {
 
         assert!(path.exists());
         assert_eq!(config.save_path(), PathBuf::from(path));
+        assert_eq!(config.seed.len(), 4);
 
         file.close()?;
         Ok(())
@@ -269,6 +270,47 @@ mod tests {
         let config = make_config()?;
         assert_eq!(config.blacklists(), None);
         assert_eq!(config.whitelists(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn seed() -> Result<()> {
+        let seed_key = "greyhounds";
+
+        let yaml_config = format!(
+            "
+            port: 5555 
+            save_path: 'default'
+            secret:
+            - key: foo
+              value: bar
+            - key: baz
+              value: woo
+            message: 
+            - new message from me
+            - test message
+            debug: 1
+            seed: {seed_key}
+        "
+        );
+        let config: Config = serde_yaml::from_str(&yaml_config)?;
+
+        let padded_string = config.seed_key();
+        let padded_string = &padded_string[seed_key.len()..padded_string.len()];
+        assert_eq!(padded_string.len(), (32 - seed_key.len()));
+        Ok(())
+    }
+
+    #[test]
+    fn pad_string() -> Result<()> {
+        let s = "hi".to_string();
+        let config = make_config()?;
+        let padded_str = config.pad_seed_key(s.clone());
+
+        assert_eq!(padded_str.len(), 32);
+        assert_ne!(s, padded_str);
+        assert!(padded_str.contains(&s));
+
         Ok(())
     }
 }

--- a/share/src/handlers/security.rs
+++ b/share/src/handlers/security.rs
@@ -127,6 +127,7 @@ mod tests {
             - {addr}
             whitelists:
             - {addr}
+            seed: config
         "
         );
         let config: Config = serde_yaml::from_str(&yaml_config)?;

--- a/share/src/item/mod.rs
+++ b/share/src/item/mod.rs
@@ -137,6 +137,7 @@ mod tests {
             - new message from me
             - test message
             debug: 1
+            seed: make
         "
         );
         let config: Config = serde_yaml::from_str(&yaml_config)?;

--- a/share/src/network/hole_puncher.rs
+++ b/share/src/network/hole_puncher.rs
@@ -23,7 +23,6 @@ use libp2p::{
     swarm::{SwarmBuilder, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
-use rand::Rng;
 use tracing::{debug, error, info, instrument};
 
 #[instrument(level = "trace")]
@@ -33,7 +32,7 @@ pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Resu
             .to_string()
             .parse()
             .unwrap();
-    let secret_key_seed = rand::thread_rng().gen_range(0..100);
+    let secret_key_seed = config.seed_key();
     let port = config.port();
 
     let local_key = generate_ed25519(secret_key_seed);
@@ -211,9 +210,8 @@ pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Resu
     })
 }
 
-fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
-    let mut bytes = [0u8; 32];
-    bytes[0] = secret_key_seed;
-
+fn generate_ed25519(mut secret_key_seed: String) -> identity::Keypair {
+    let bytes = unsafe { secret_key_seed.as_bytes_mut() };
+    println!("{}", bytes.len());
     identity::Keypair::ed25519_from_bytes(bytes).expect("only errors on wrong length")
 }


### PR DESCRIPTION
This PR solves the issue of getting a random peer id. A peer id can now be deterministic by setting a value we call seed key in the config file. 
Check the readme for instructions.