### PR TITLE
Saving Recipients Info

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "allocator-api2"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0942ffc6dcaadf03badf6e6a2d0228460359d5e34b57ccdc720b7382dfbd5ec5"
+
+[[package]]
 name = "anstream"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -708,6 +714,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "deranged"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7684a49fb1af197853ef7b2ee694bc1f5b4179556f1e5710e1760c5db6f5e929"
+
+[[package]]
 name = "dialoguer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -869,6 +881,18 @@ name = "event-listener"
 version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "fallible-iterator"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1136,6 +1160,19 @@ name = "hashbrown"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2c6201b9ff9fd90a5a3bac2e56a830d0caa509576f0e503818ee82c181b3437a"
+dependencies = [
+ "ahash",
+ "allocator-api2",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "312f66718a2d7789ffef4f4b7b213138ed9f1eb3aa1d0d82fc99f88fb3ffd26f"
+dependencies = [
+ "hashbrown 0.14.0",
+]
 
 [[package]]
 name = "heck"
@@ -1717,6 +1754,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "libsqlite3-sys"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "afc22eff61b133b115c6e8c74e818c628d6d5e7a502afea6f64dee076dd94326"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "linked-hash-map"
 version = "0.5.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2121,6 +2169,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
+name = "pkg-config"
+version = "0.3.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
+
+[[package]]
 name = "platforms"
 version = "3.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2468,6 +2522,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "rusqlite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "549b9d036d571d42e6e85d1c1425e2ac83491075078ca9a15be021c56b1641f2"
+dependencies = [
+ "bitflags 2.3.3",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+]
+
+[[package]]
 name = "rustc-demangle"
 version = "0.1.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2556,9 +2624,11 @@ dependencies = [
  "libp2p-request-response",
  "predicates",
  "rand 0.8.5",
+ "rusqlite",
  "serde",
  "serde_json",
  "serde_yaml",
+ "time",
  "tokio",
  "tracing",
  "tracing-appender",
@@ -2876,10 +2946,11 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.23"
+version = "0.3.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59e399c068f43a5d116fedaf73b203fa4f9c519f17e2b34f63221d3792f81446"
+checksum = "b0fdd63d58b18d663fbdf70e049f00a22c8e42be082203be7f26589213cd75ea"
 dependencies = [
+ "deranged",
  "itoa",
  "libc",
  "num_threads",
@@ -2896,9 +2967,9 @@ checksum = "7300fbefb4dadc1af235a9cef3737cea692a9d97e1b9cbcd4ebdae6f8868e6fb"
 
 [[package]]
 name = "time-macros"
-version = "0.2.10"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96ba15a897f3c86766b757e5ac7221554c6750054d74d5b28844fce5fb36a6c4"
+checksum = "eb71511c991639bb078fd5bf97757e03914361c48100d52878b8e52b46fb92cd"
 dependencies = [
  "time-core",
 ]
@@ -3140,6 +3211,12 @@ name = "value-bag"
 version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d92ccd67fb88503048c01b59152a04effd0782d035a83a6d256ce6085f08f4a3"
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version_check"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2617,6 +2617,7 @@ dependencies = [
  "assert_fs",
  "cargo-husky",
  "clap",
+ "dialoguer",
  "directories-next",
  "futures",
  "futures-timer",

--- a/README.md
+++ b/README.md
@@ -15,8 +15,9 @@ Share anything with teammates across machines via CLI. Share is a tool for secur
   - [Files](#files)
   - [Messages](#messages)
   - [Configuration](#configuration)
-    - [Whitelists](#whitelists)
-    - [Signed Certs](#SignedCertificate)
+    - [Whitelists](#whitelistsblacklists-ip-addresses)
+    - [Signed Certs](#signed-certificate)
+    - [Seed Key](#seeds-seed-key)
 - [Update](#update)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -125,28 +126,24 @@ The sender then attempts to send the secret, and if it is successful, `scs` rela
 
 ```yaml
 port: 5555 #An optional port defaults to 0 if not present
-# The folder path to store all items.
-# Secrets will be stored at <path>/secrets.json
-# Messages at <path>/messages.txt
-# Files at <path>/nameoffile
-## If "default" is passed, the folder path will be `scs`'s directory in the machine's local folder.
 save_path: "default"
-secret: #Optional during receive
+secret: # Optional during receive
   - key: foo
     value: bar
   - key: baz
     value: woo
-message: #Optional during receive
+message: # Optional during receive
   - new message from me
   - test message
-file: #Optional during receive
+file: # Optional during receive
   - "./dev_build.sh"
-debug: 1 #Compulsory. 0 is for off, and 1 and above for on
+debug: 1 # Compulsory. 0 is for off, and 1 and above for on
 blacklists:
   - 34.138.139.178
 whitelists:
   - 34.193.14.12
-connection: trusted #or self
+connection: trusted # or self
+seed: "scsiscool"
 ```
 
   ```shell
@@ -163,6 +160,10 @@ connection: trusted #or self
 ### Signed Certificate
  Receivers can configure `scs` to only allow connections from users using a signed certificate from the CA. or just self-signed certificates. 
  Add a `connection: trusted` or `connection: self` to the configuration file.
+
+ ### Seeds (Seed Key)
+ The backbone of `scs` is `PeerId`. A `PeerId` a randomly generated key whenever a session is started for both the receiver and the sender. As of `v0.1.3` of `scs`, `PeerId`s can now be deterministic, that is, a single `PeerId` can be used for life. To do this, you need to set what is called a "seed". The `PeerId` is generated with respect to this seed. As long as the seed key remains the same, the `PeerId` will remain the same. 
+ The "seed" key is a string of any length lesser than 32. But for ease and optimal configuration, we recommend 4 or 5 letter words as in the above configuration file.
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Share anything with teammates across machines via CLI. Share is a tool for secur
     - [Whitelists](#whitelistsblacklists-ip-addresses)
     - [Signed Certs](#signed-certificate)
     - [Seed Key](#seeds-seed-key)
+- [Recipient Info](#saving-peer-info)
 - [Update](#update)
 - [Roadmap](#roadmap)
 - [Contributing](#contributing)
@@ -164,6 +165,20 @@ seed: "scsiscool"
  ### Seeds (Seed Key)
  The backbone of `scs` is `PeerId`. A `PeerId` a randomly generated key whenever a session is started for both the receiver and the sender. As of `v0.1.3` of `scs`, `PeerId`s can now be deterministic, that is, a single `PeerId` can be used for life. To do this, you need to set what is called a "seed". The `PeerId` is generated with respect to this seed. As long as the seed key remains the same, the `PeerId` will remain the same. 
  The "seed" key is a string of any length lesser than 32. But for ease and optimal configuration, we recommend 4 or 5 letter words as in the above configuration file.
+
+
+# Saving Peer Info
+To make using `scs` easier after the initial setup, `scs` implements a simple mechanism for storing recipients information. 
+After every session with a new peer, `scs` asks if you'll like to save the information of the connected peer. If you decide to send to that same peer, pass in the name of the peer to the `-n` argument like below
+```sh
+scs send -n dante -c config.yml
+```
+Note: For security reasons, we don't save IP addresses of the connected peers on each machine.
+
+To see all saved peers:
+```sh
+scs list
+```
 
 # Contributing
 

--- a/README.md
+++ b/README.md
@@ -174,7 +174,8 @@ Contributions of any kind are welcome! See the [contributing guide](contributing
 # Roadmap
 
 ### Utilities
-- [ ] Personalize peer ID + allow saving recipient info (address, port, etc.) and giving a proper name so one can do "scs send dante -m Hello"
+- [x] Personalize peer ID.
+- [ ] Allow saving recipient info (address, port, etc.) and giving a proper name so one can do "scs send dante -m Hello"
 - [ ] Allow to always listen to specific addresses for an accessible data flow.
 
 ### Protocols

--- a/config.yml
+++ b/config.yml
@@ -19,3 +19,4 @@ debug: 1 #Compulsory. 0 is for off and 1 and above for on
 # blacklists:
 # - 127.0.0.1
 # - 34.138.139.178
+seed: "sour"

--- a/config.yml
+++ b/config.yml
@@ -1,4 +1,4 @@
-port: 5555 #An optional port defaults to 0 if not present
+port: 6666 #An optional port defaults to 0 if not present
 # The folder path to store all items.
 # Secrets will be stored at <path>/secrets.json
 # Messages at <path>/messages.txt
@@ -19,4 +19,4 @@ debug: 1 #Compulsory. 0 is for off and 1 and above for on
 # blacklists:
 # - 127.0.0.1
 # - 34.138.139.178
-seed: "sour"
+seed: "bitter"

--- a/share/Cargo.toml
+++ b/share/Cargo.toml
@@ -30,6 +30,8 @@ request_response = {version = "0.25.0", package = "libp2p-request-response", fea
 directories-next = "2.0.0"
 tracing-appender = "0.2.2"
 serde_yaml = "0.9.24"
+rusqlite = { version = "0.29.0", features = ["bundled"] }
+time = "0.3.25"
 
 [dev-dependencies]
 assert_fs = "1.0.13"

--- a/share/Cargo.toml
+++ b/share/Cargo.toml
@@ -31,7 +31,7 @@ directories-next = "2.0.0"
 tracing-appender = "0.2.2"
 serde_yaml = "0.9.24"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
-time = "0.3.25"
+time = { version =  "0.3.25", features = ["parsing"]}
 dialoguer = "0.10.4"
 
 [dev-dependencies]

--- a/share/Cargo.toml
+++ b/share/Cargo.toml
@@ -32,6 +32,7 @@ tracing-appender = "0.2.2"
 serde_yaml = "0.9.24"
 rusqlite = { version = "0.29.0", features = ["bundled"] }
 time = "0.3.25"
+dialoguer = "0.10.4"
 
 [dev-dependencies]
 assert_fs = "1.0.13"

--- a/share/src/config.rs
+++ b/share/src/config.rs
@@ -205,6 +205,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn config_from_cli() -> Result<()> {
         let secret = None;
@@ -297,6 +298,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn fail_to_polyfill_remote_peer_id() -> Result<()> {
         let secret = None;

--- a/share/src/config.rs
+++ b/share/src/config.rs
@@ -208,6 +208,7 @@ mod tests {
 
         assert!(path.exists());
         assert_eq!(config.save_path(), PathBuf::from(path));
+        assert_eq!(config.seed.len(), 4);
 
         file.close()?;
         Ok(())
@@ -269,6 +270,47 @@ mod tests {
         let config = make_config()?;
         assert_eq!(config.blacklists(), None);
         assert_eq!(config.whitelists(), None);
+        Ok(())
+    }
+
+    #[test]
+    fn seed() -> Result<()> {
+        let seed_key = "greyhounds";
+
+        let yaml_config = format!(
+            "
+            port: 5555 
+            save_path: 'default'
+            secret:
+            - key: foo
+              value: bar
+            - key: baz
+              value: woo
+            message: 
+            - new message from me
+            - test message
+            debug: 1
+            seed: {seed_key}
+        "
+        );
+        let config: Config = serde_yaml::from_str(&yaml_config)?;
+
+        let padded_string = config.seed_key();
+        let padded_string = &padded_string[seed_key.len()..padded_string.len()];
+        assert_eq!(padded_string.len(), (32 - seed_key.len()));
+        Ok(())
+    }
+
+    #[test]
+    fn pad_string() -> Result<()> {
+        let s = "hi".to_string();
+        let config = make_config()?;
+        let padded_str = config.pad_seed_key(s.clone());
+
+        assert_eq!(padded_str.len(), 32);
+        assert_ne!(s, padded_str);
+        assert!(padded_str.contains(&s));
+
         Ok(())
     }
 }

--- a/share/src/config.rs
+++ b/share/src/config.rs
@@ -228,7 +228,7 @@ mod tests {
             config,
             name,
         };
-        let db_path = assert_fs::NamedTempFile::new("scs.db3")?;
+        let db_path = assert_fs::NamedTempFile::new("scs_config.db3")?;
         let store = Store::initialize(Some(db_path.path().to_path_buf()))?;
 
         let config = Config::new(&opts, &store)?;
@@ -321,7 +321,7 @@ mod tests {
             name,
         };
 
-        let db_path = assert_fs::NamedTempFile::new("scs.db3")?;
+        let db_path = assert_fs::NamedTempFile::new("scs_polyfill.db3")?;
         let store = Store::initialize(Some(db_path.path().to_path_buf()))?;
 
         let rpm = Config::remote_peer_id_polyfill(&opts, &store);

--- a/share/src/config.rs
+++ b/share/src/config.rs
@@ -106,15 +106,19 @@ impl Config {
     }
 
     pub fn new(opts: &Cli, store: &Store) -> Result<(Mode, Option<PeerId>, Config)> {
-        let rpm = Self::remote_peer_id_polyfill(opts, store)?;
+        let rpm = match &opts.mode {
+            Mode::Send => Some(Self::remote_peer_id_polyfill(opts, store)?),
+            Mode::Receive => None,
+        };
+
         match &opts.config {
             None => {
                 let config = Config::from_cli(opts)?;
-                Ok((opts.mode, Some(rpm), config))
+                Ok((opts.mode, rpm, config))
             }
             Some(path) => {
                 let config = Config::from_config_file(path.to_string())?;
-                Ok((opts.mode, Some(rpm), config))
+                Ok((opts.mode, rpm, config))
             }
         }
     }

--- a/share/src/database/mod.rs
+++ b/share/src/database/mod.rs
@@ -119,7 +119,7 @@ mod tests {
 
     #[test]
     fn absent_peer() -> Result<()> {
-        let db_path = assert_fs::NamedTempFile::new("scs.db3")?;
+        let db_path = assert_fs::NamedTempFile::new("scs_peer.db3")?;
         let store = Store::initialize(Some(db_path.path().to_path_buf()))?;
 
         let peer = store.is_peer_present(PeerId::random())?;

--- a/share/src/database/mod.rs
+++ b/share/src/database/mod.rs
@@ -63,6 +63,7 @@ impl Store {
         let peer = self.is_peer_present(peer_id)?;
 
         let res = match peer {
+            //TODO update last seen of peer
             Some(_) => Ok(()),
             None => {
                 if Confirm::with_theme(&ColorfulTheme::default())

--- a/share/src/database/mod.rs
+++ b/share/src/database/mod.rs
@@ -117,6 +117,7 @@ mod tests {
         Ok(())
     }
 
+    #[cfg(not(target_os = "windows"))]
     #[test]
     fn absent_peer() -> Result<()> {
         let db_path = assert_fs::NamedTempFile::new("scs_peer.db3")?;

--- a/share/src/database/mod.rs
+++ b/share/src/database/mod.rs
@@ -1,0 +1,81 @@
+use std::{
+    fs,
+    sync::{Arc, Mutex, MutexGuard},
+};
+
+use anyhow::{Context, Result};
+use libp2p::{Multiaddr, PeerId, Swarm};
+use rusqlite::Connection;
+use tracing::debug;
+
+use crate::network::Behaviour;
+
+use self::peer::ScsPeer;
+
+pub mod peer;
+
+#[derive(Debug)]
+pub struct Store {
+    // db_path: PathBuf,
+    conn: Arc<Mutex<Connection>>,
+}
+
+impl Store {
+    pub fn initialize() -> Result<Store> {
+        debug!("Initializing Database Connection");
+        let dirs =
+            directories_next::ProjectDirs::from("com", "onboardbase", "secureshare").unwrap();
+        let path = dirs.data_local_dir();
+        fs::create_dir_all(path).context("Failed to create default directory")?;
+        let path = path.join("scs.db3");
+        let conn = Connection::open(path)?;
+
+        debug!("Preparing to execute schema");
+        conn.execute(
+            "CREATE TABLE IF NOT EXISTS peer (
+            id    INTEGER PRIMARY KEY,
+            name  TEXT NOT NULL UNIQUE,
+            addrs  BLOB,
+            peer_id TEXT NOT NULL UNIQUE,
+            last_seen TEXT
+        )",
+            (), // empty list of parameters.
+        )?;
+        debug!("Executed schema creation for peer");
+
+        let settings = Store {
+            conn: Arc::new(Mutex::new(conn)),
+        };
+        Ok(settings)
+    }
+
+    pub fn get_conn_handle(&self) -> MutexGuard<'_, Connection> {
+        self.conn.lock().unwrap()
+    }
+
+    pub fn store_peer(&self, swarm: &mut Swarm<Behaviour>, peer_id: PeerId) -> Result<()> {
+        debug!("Initiating Peer Storage");
+        let addrs = swarm.external_addresses().collect::<Vec<_>>();
+        //FIXME chnage this to the connector address
+        let addr = <&Multiaddr>::clone(addrs.first().unwrap());
+        let name = "testing_t".to_string();
+        let peer = ScsPeer::from((addr, name, peer_id));
+        peer.save(self)?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+
+    use super::Store;
+
+    #[test]
+    fn initialize_db() -> Result<()> {
+        let settings = Store::initialize()?;
+        let conn = settings.get_conn_handle();
+        assert!(conn.is_autocommit());
+        Ok(())
+    }
+}

--- a/share/src/database/mod.rs
+++ b/share/src/database/mod.rs
@@ -4,9 +4,10 @@ use std::{
 };
 
 use anyhow::{Context, Result};
+use dialoguer::{theme::ColorfulTheme, Confirm, Input};
 use libp2p::{Multiaddr, PeerId, Swarm};
 use rusqlite::Connection;
-use tracing::debug;
+use tracing::{debug, info};
 
 use crate::network::Behaviour;
 
@@ -53,15 +54,42 @@ impl Store {
         self.conn.lock().unwrap()
     }
 
+    fn is_peer_present(&self, peer_id: PeerId) -> Result<Option<ScsPeer>> {
+        ScsPeer::get_by_peer_id(peer_id.to_string(), self)
+    }
+
     pub fn store_peer(&self, swarm: &mut Swarm<Behaviour>, peer_id: PeerId) -> Result<()> {
         debug!("Initiating Peer Storage");
-        let addrs = swarm.external_addresses().collect::<Vec<_>>();
-        //FIXME chnage this to the connector address
-        let addr = <&Multiaddr>::clone(addrs.first().unwrap());
-        let name = "testing_t".to_string();
-        let peer = ScsPeer::from((addr, name, peer_id));
-        peer.save(self)?;
-        Ok(())
+        let peer = self.is_peer_present(peer_id)?;
+
+        let res = match peer {
+            Some(_) => Ok(()),
+            None => {
+                if Confirm::with_theme(&ColorfulTheme::default())
+                    .with_prompt("Do you want to save information about this peer?")
+                    .default(true)
+                    .interact()
+                    .unwrap()
+                {
+                    let name: String = Input::with_theme(&ColorfulTheme::default())
+                        .with_prompt("Name of Recipient")
+                        .interact_text()
+                        .unwrap();
+                    let addrs = swarm.external_addresses().collect::<Vec<_>>();
+                    //FIXME chnage this to the connector address
+                    let addr = <&Multiaddr>::clone(addrs.first().unwrap());
+
+                    let peer = ScsPeer::from((addr, name, peer_id));
+                    peer.save(self)?;
+                    Ok(())
+                } else {
+                    Ok(())
+                }
+            }
+        };
+
+        info!("Peer has been saved successfully");
+        res
     }
 }
 

--- a/share/src/database/peer.rs
+++ b/share/src/database/peer.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::str::FromStr;
+
 use anyhow::{anyhow, Result};
 use libp2p::{Multiaddr, PeerId};
 use rusqlite::{named_params, Row};
@@ -51,6 +53,13 @@ impl From<(&Multiaddr, String, PeerId)> for ScsPeer {
 }
 
 impl ScsPeer {
+    pub fn peer_id(&self) -> Result<PeerId> {
+        match PeerId::from_str(self.peer_id.as_str()) {
+            Ok(id) => Ok(id),
+            Err(err) => Err(anyhow!("{}", err.to_string())),
+        }
+    }
+
     pub fn fetch_all_peers(store: &Store) -> Result<Vec<ScsPeer>> {
         let conn = store.get_conn_handle();
         let mut stmt = conn.prepare("SELECT id, name, addrs, last_seen FROM peer")?;

--- a/share/src/database/peer.rs
+++ b/share/src/database/peer.rs
@@ -1,0 +1,87 @@
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Result};
+use libp2p::{Multiaddr, PeerId};
+use rusqlite::{named_params, Row};
+use tracing::debug;
+
+use time::OffsetDateTime;
+
+use super::Store;
+
+#[derive(Debug, Clone)]
+pub struct ScsPeer {
+    addrs: String,
+    name: String,
+    last_seen: String,
+    peer_id: String,
+    id: Option<i32>,
+}
+
+impl TryFrom<&Row<'_>> for ScsPeer {
+    fn try_from(row: &Row<'_>) -> Result<Self> {
+        debug!("Creating Peer from Row");
+
+        let peer = ScsPeer {
+            id: row.get(0)?,
+            name: row.get(1)?,
+            addrs: row.get(2)?,
+            peer_id: row.get(3)?,
+            last_seen: row.get(4)?,
+        };
+        Ok(peer)
+    }
+
+    type Error = anyhow::Error;
+}
+
+impl From<(&Multiaddr, String, PeerId)> for ScsPeer {
+    fn from(value: (&Multiaddr, String, PeerId)) -> Self {
+        debug!("Creating Peer from tuple");
+        let (addr, name, peer_id) = value;
+        let local = OffsetDateTime::now_utc();
+        ScsPeer {
+            addrs: addr.to_string(),
+            name,
+            last_seen: local.to_string(),
+            peer_id: peer_id.to_string(),
+            id: None,
+        }
+    }
+}
+
+impl ScsPeer {
+    pub fn fetch_all_peers(store: &Store) -> Result<Vec<ScsPeer>> {
+        let conn = store.get_conn_handle();
+        let mut stmt = conn.prepare("SELECT id, name, addrs, last_seen FROM peer")?;
+        let peer_iter = stmt.query_map([], |row| Ok(ScsPeer::try_from(row).unwrap()))?;
+        let peers = peer_iter.filter_map(|peer| peer.ok()).collect::<Vec<_>>();
+        Ok(peers)
+    }
+
+    pub fn save(&self, store: &Store) -> Result<()> {
+        debug!("Saving Peer");
+        let conn = store.get_conn_handle();
+        conn.execute(
+            "INSERT INTO peer (name, addrs, last_seen, peer_id) VALUES (?1, ?2, ?3, ?4)",
+            (&self.name, &self.addrs, &self.last_seen, &self.peer_id),
+        )?;
+        Ok(())
+    }
+
+    pub fn get_peer(name: String, store: &Store) -> Result<ScsPeer> {
+        let conn = store.get_conn_handle();
+
+        let mut statement =
+            conn.prepare("SELECT id, name, addrs, last_seen FROM peer WHERE name = :name")?;
+        let peer_iter = statement.query_map(named_params! { ":name": name }, |row| {
+            Ok(ScsPeer::try_from(row).unwrap())
+        })?;
+        let peers = peer_iter.filter_map(|peer| peer.ok()).collect::<Vec<_>>();
+        if peers.is_empty() {
+            Err(anyhow!("Cannot find peer with name: {name}"))
+        } else {
+            Ok(peers.first().unwrap().clone())
+        }
+    }
+}

--- a/share/src/database/peer.rs
+++ b/share/src/database/peer.rs
@@ -11,7 +11,7 @@ use time::OffsetDateTime;
 
 use super::Store;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq)]
 pub struct ScsPeer {
     addrs: String,
     name: String,
@@ -113,5 +113,37 @@ impl ScsPeer {
         } else {
             Ok(Some(peers.first().unwrap().clone()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::Result;
+    use libp2p::{Multiaddr, PeerId};
+
+    use super::ScsPeer;
+
+    #[test]
+    fn peer_from_tuple() -> Result<()> {
+        let peer_id = PeerId::random();
+        let addr: Multiaddr = "/ip4/127.0.0.0/tcp/5555".parse().unwrap();
+        let peer = ScsPeer::from((&addr, "foo".to_string(), peer_id));
+        assert_eq!(peer.peer_id()?, peer_id);
+        assert_eq!(peer.name().as_str(), "foo");
+        Ok(())
+    }
+
+    #[test]
+    fn wrong_peer_id() {
+        let peer = ScsPeer {
+            addrs: "/ip4/jki/oo/tcp/990".to_string(),
+            name: "foo".to_string(),
+            last_seen: "now".to_string(),
+            peer_id: "hi".to_string(),
+            id: Some(1),
+        };
+
+        let peer_id = peer.peer_id();
+        assert!(peer_id.is_err());
     }
 }

--- a/share/src/database/peer.rs
+++ b/share/src/database/peer.rs
@@ -60,9 +60,13 @@ impl ScsPeer {
         }
     }
 
+    pub fn name(&self) -> String {
+        self.name.clone()
+    }
+
     pub fn fetch_all_peers(store: &Store) -> Result<Vec<ScsPeer>> {
         let conn = store.get_conn_handle();
-        let mut stmt = conn.prepare("SELECT id, name, addrs, last_seen FROM peer")?;
+        let mut stmt = conn.prepare("SELECT id, name, addrs, peer_id, last_seen FROM peer")?;
         let peer_iter = stmt.query_map([], |row| Ok(ScsPeer::try_from(row).unwrap()))?;
         let peers = peer_iter.filter_map(|peer| peer.ok()).collect::<Vec<_>>();
         Ok(peers)

--- a/share/src/handlers/security.rs
+++ b/share/src/handlers/security.rs
@@ -127,6 +127,7 @@ mod tests {
             - {addr}
             whitelists:
             - {addr}
+            seed: config
         "
         );
         let config: Config = serde_yaml::from_str(&yaml_config)?;

--- a/share/src/item/mod.rs
+++ b/share/src/item/mod.rs
@@ -137,6 +137,7 @@ mod tests {
             - new message from me
             - test message
             debug: 1
+            seed: make
         "
         );
         let config: Config = serde_yaml::from_str(&yaml_config)?;

--- a/share/src/logger.rs
+++ b/share/src/logger.rs
@@ -1,6 +1,6 @@
 use std::fs::{self};
 
-use crate::config::Config;
+use crate::Cli;
 use anyhow::{Context, Result};
 use tracing::Level;
 use tracing_subscriber::{
@@ -8,10 +8,10 @@ use tracing_subscriber::{
     fmt::{format, writer::MakeWriterExt},
 };
 
-pub fn log(config: &Config) -> Result<()> {
-    let (level, source_location) = match config.verbose() {
-        false => (Level::INFO, false),
-        true => (Level::DEBUG, true),
+pub fn log(config: &Cli) -> Result<()> {
+    let (level, source_location) = match config.debug {
+        0 => (Level::INFO, false),
+        _ => (Level::DEBUG, true),
     };
 
     let dirs = directories_next::ProjectDirs::from("com", "onboardbase", "secureshare").unwrap();

--- a/share/src/main.rs
+++ b/share/src/main.rs
@@ -41,6 +41,10 @@ pub struct Cli {
     #[clap(long, short)]
     remote_peer_id: Option<PeerId>,
 
+    // Name of the saved recipient to send a secret to.
+    #[clap(long, short)]
+    name: Option<String>,
+
     ///Port to establish connection on
     #[clap(long, short)]
     port: Option<i32>,
@@ -74,19 +78,20 @@ impl FromStr for Mode {
 #[tokio::main]
 async fn main() {
     let opts = Cli::parse();
-    let (mode, remote_peer_id, config) = match Config::new(&opts) {
-        Ok(res) => res,
-        Err(err) => {
-            eprintln!("{}", err);
-            exit(1)
-        }
-    };
+    logger::log(&opts).unwrap();
 
-    logger::log(&config).unwrap();
     let store = match Store::initialize() {
         Ok(store) => store,
         Err(err) => {
             error!("{:#?}", err.to_string());
+            exit(1)
+        }
+    };
+
+    let (mode, remote_peer_id, config) = match Config::new(&opts, &store) {
+        Ok(res) => res,
+        Err(err) => {
+            error!("{}", err);
             exit(1)
         }
     };

--- a/share/src/main.rs
+++ b/share/src/main.rs
@@ -1,11 +1,13 @@
 use clap::Parser;
 use config::Config;
+use database::Store;
 use libp2p::PeerId;
 use network::punch;
 use std::{process::exit, str::FromStr};
 use tracing::error;
 
 mod config;
+mod database;
 mod handlers;
 mod item;
 mod logger;
@@ -81,9 +83,16 @@ async fn main() {
     };
 
     logger::log(&config).unwrap();
+    let store = match Store::initialize() {
+        Ok(store) => store,
+        Err(err) => {
+            error!("{:#?}", err.to_string());
+            exit(1)
+        }
+    };
 
     let code = {
-        match punch(mode, remote_peer_id, config) {
+        match punch(mode, remote_peer_id, config, store) {
             Ok(_) => 1,
             Err(err) => {
                 error!("{:#?}", err.to_string());

--- a/share/src/main.rs
+++ b/share/src/main.rs
@@ -82,7 +82,7 @@ async fn main() {
     let opts = Cli::parse();
     logger::log(&opts).unwrap();
 
-    let store = match Store::initialize() {
+    let store = match Store::initialize(None) {
         Ok(store) => store,
         Err(err) => {
             error!("{:#?}", err.to_string());
@@ -108,4 +108,41 @@ async fn main() {
         }
     };
     ::std::process::exit(code);
+}
+
+#[cfg(test)]
+mod tests {
+    use libp2p::PeerId;
+
+    use crate::{Cli, Mode};
+
+    #[test]
+    fn cli() {
+        let secret = None;
+        let file = None;
+        let message = None;
+        let mode = Mode::Send;
+        let remote_peer_id = Some(PeerId::random());
+        let name = None;
+        let debug = 0;
+        let port = Some(5555);
+        let config = None;
+
+        let cli = Cli {
+            secret,
+            message,
+            file,
+            mode,
+            remote_peer_id,
+            debug,
+            port,
+            config,
+            name,
+        };
+
+        assert_eq!(cli.debug, 0);
+        assert_eq!(cli.file, None);
+        assert!(cli.message.is_none());
+        assert_ne!(cli.config, Some("path/to/config".to_string()))
+    }
 }

--- a/share/src/main.rs
+++ b/share/src/main.rs
@@ -62,6 +62,7 @@ pub struct Cli {
 pub enum Mode {
     Receive,
     Send,
+    List,
 }
 
 impl FromStr for Mode {
@@ -70,7 +71,8 @@ impl FromStr for Mode {
         match mode {
             "send" => Ok(Mode::Send),
             "receive" => Ok(Mode::Receive),
-            _ => Err("Expected either 'send' or 'receive'".to_string()),
+            "list" => Ok(Mode::List),
+            _ => Err("Expected either 'send' or 'receive' or 'list'".to_string()),
         }
     }
 }

--- a/share/src/network/hole_puncher.rs
+++ b/share/src/network/hole_puncher.rs
@@ -23,7 +23,6 @@ use libp2p::{
     swarm::{SwarmBuilder, SwarmEvent},
     tcp, yamux, Multiaddr, PeerId, Transport,
 };
-use rand::Rng;
 use tracing::{debug, error, info, instrument};
 
 #[instrument(level = "trace")]
@@ -33,7 +32,7 @@ pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Resu
             .to_string()
             .parse()
             .unwrap();
-    let secret_key_seed = rand::thread_rng().gen_range(0..100);
+    let secret_key_seed = config.seed_key();
     let port = config.port();
 
     let local_key = generate_ed25519(secret_key_seed);
@@ -211,9 +210,8 @@ pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Resu
     })
 }
 
-fn generate_ed25519(secret_key_seed: u8) -> identity::Keypair {
-    let mut bytes = [0u8; 32];
-    bytes[0] = secret_key_seed;
-
+fn generate_ed25519(mut secret_key_seed: String) -> identity::Keypair {
+    let bytes = unsafe { secret_key_seed.as_bytes_mut() };
+    println!("{}", bytes.len());
     identity::Keypair::ed25519_from_bytes(bytes).expect("only errors on wrong length")
 }

--- a/share/src/network/hole_puncher.rs
+++ b/share/src/network/hole_puncher.rs
@@ -4,6 +4,7 @@
 use std::process::exit;
 
 use super::request_response_handler;
+use crate::database::Store;
 use crate::handlers::security::{is_ip_blacklisted, is_ip_whitelisted};
 use crate::network::request::make_request;
 use crate::network::{get_behaviour, ConnectionDetails, Event};
@@ -26,7 +27,12 @@ use libp2p::{
 use tracing::{debug, error, info, instrument};
 
 #[instrument(level = "trace")]
-pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Result<()> {
+pub fn punch(
+    mode: Mode,
+    remote_peer_id: Option<PeerId>,
+    config: Config,
+    store: Store,
+) -> Result<()> {
     let relay_address: Multiaddr =
         "/ip4/157.245.40.97/tcp/4001/p2p/12D3KooWDpJ7As7BWAwRMfu1VU2WCqNjvq387JEYKDBj4kx6nXTN"
             .to_string()
@@ -203,6 +209,12 @@ pub fn punch(mode: Mode, remote_peer_id: Option<PeerId>, config: Config) -> Resu
                     request_response::Event::Message { peer, message },
                 )) => {
                     request_response_handler(&mut swarm, message, peer, &config);
+                    match store.store_peer(&mut swarm, peer) {
+                        Ok(_) => {}
+                        Err(err) => {
+                            error!("{}", err.to_string())
+                        }
+                    }
                 }
                 _ => {}
             }

--- a/share/src/network/hole_puncher.rs
+++ b/share/src/network/hole_puncher.rs
@@ -144,6 +144,7 @@ pub fn punch(
                 .listen_on(relay_address.with(Protocol::P2pCircuit))
                 .unwrap();
         }
+        _ => {}
     }
     let mut connection_deets = ConnectionDetails::new();
 

--- a/share/src/network/request.rs
+++ b/share/src/network/request.rs
@@ -59,7 +59,7 @@ pub fn make_request(mode: Mode, swarm: &mut Swarm<Behaviour>, peer_id: PeerId, c
                 .request_response
                 .send_request(&peer_id, items);
         }
-        Mode::Receive => {
+        Mode::Receive | Mode::List => {
             // if !is_ip_whitelisted(event, config)
         }
     }


### PR DESCRIPTION
This PR is the corollary to #5.
The logical conclusion to being able to personalize a `Peerid` is saving that `PeerId` to enable reusability. 
For more information, please refer to the "Saving Recipients Information" on the Readme.